### PR TITLE
Added Breadcrumbs to the Wizard following these principles:

### DIFF
--- a/src/components/WizardBreadCrumbs.vue
+++ b/src/components/WizardBreadCrumbs.vue
@@ -1,0 +1,41 @@
+//Component from https://gist.github.com/AnoRebel/0690388ca901523d51476fd35d3037ab
+<template>
+  <nav class="wizardbreadcrumbs__navbar" aria-label="Breadcrumb">
+    <ul class="wizardbreadcrumbs__list" >
+      <li class="wizardbreadcrumbs__itemlist" v-for="(item, index) in items" :key="index">
+        <svg v-if="index != 0" xmlns="http://www.w3.org/2000/svg" version="1.1" width="24" height="24">
+          <path d="m 12,6 10,10 -10,10 z" :fill=" getColor(index)  "/>
+          </svg>
+          <span v-if="item == selected" class="wizardbreadcrumbs__item wizardbreadcrumbs__selected">{{ item }}</span>
+          <span v-else="" class="wizardbreadcrumbs__item" >{{ item }}</span>
+        </li>
+        </ul>
+  </nav>
+</template>
+<script>
+
+ 
+
+export default {
+    name: "Breadcrumbs",
+    methods: {
+      getColor(index) {
+        const colors = ["#13678a","#9aeba3","#dafdba"]
+        index = index % colors.length;
+        console.log(index);
+        return colors[index];
+      }
+    },
+    props: {
+        items: {
+            type: Array,
+            required: true,
+        },
+        selected: {
+          type: String,
+          required: true,
+          default: "Events"
+        }
+    },
+}
+</script>

--- a/src/components/WizardStepCategory.vue
+++ b/src/components/WizardStepCategory.vue
@@ -38,6 +38,9 @@ await getWizardCategories();
   <div v-if="categories" class="wizard__step">
     <h1 class="wizard__title">{{ $t('wizard.category.title') }}</h1>
     <h2 class="wizard__subtitle">{{ $t('wizard.category.subtitle') }}</h2>
+    <div class="wizard__breadcrumbs">
+      <WizardBreadCrumbs :items="Object.values(WizardStep).filter(x => typeof x === 'string')" :selected="WizardStep[wizardStore.currentStep]" />
+    </div>
     <div class="wizard__options">
       <WizardOption
         v-for="{ id, name, icon } in categories.value"

--- a/src/components/WizardStepEvent.vue
+++ b/src/components/WizardStepEvent.vue
@@ -27,6 +27,9 @@ await getEventTypes();
   <div v-if="eventTypes" class="wizard__step">
     <h1 class="wizard__title">{{ $t('wizard.event.title') }}</h1>
     <h2 class="wizard__subtitle">{{ $t('wizard.event.subtitle') }}</h2>
+    <div class="wizard__breadcrumbs">
+      <WizardBreadCrumbs :items="Object.values(WizardStep).filter(x => typeof x === 'string')" :selected="WizardStep[wizardStore.currentStep]" />
+    </div>
     <div class="wizard__options">
       <WizardOption
         v-for="{ id, name, icon } in eventTypes.value"

--- a/src/components/WizardStepTechnology.vue
+++ b/src/components/WizardStepTechnology.vue
@@ -38,6 +38,9 @@ await getWizardTechnologies(wizardStore.categories);
   <div v-if="technologies" class="wizard__step">
     <h1 class="wizard__title">{{ $t('wizard.category.title') }}</h1>
     <h2 class="wizard__subtitle">{{ $t('wizard.category.subtitle') }}</h2>
+    <div class="wizard__breadcrumbs">
+      <WizardBreadCrumbs :items="Object.values(WizardStep).filter(x => typeof x === 'string')" :selected="WizardStep[wizardStore.currentStep]" />
+    </div>
     <div class="wizard__options">
       <WizardOption
         v-for="{ id, name, icon } in technologies.value"

--- a/src/pages/wizard.vue
+++ b/src/pages/wizard.vue
@@ -57,6 +57,36 @@ checkIfUserIsLogged(user);
     }
   }
 }
+
+.wizardbreadcrumbs {
+
+  &__navbar {
+    list-style: none;
+    display: flex;
+    justify-content: center;
+  }
+
+  &__itemlist{
+    display: inline-block;
+  }
+
+  &__list {
+    
+  }
+
+  &__item {
+    height: 100%;
+    margin-left: 10px;
+    color: lightgray;
+  }
+
+  &__selected {
+    color: #45c4b0;
+    font-weight: bold;
+  }
+
+}
+
 </style>
 
 <template>


### PR DESCRIPTION
Related to issue #9  

- It uses the steps defined in the enum WizardStep.
 - It highlight changing the color the step of the wizard we are located at the moment. Other steps are in light-gray to focus on the selected one.
 - It created a new Vue component to manage the creation of the breadcrumbs.
 - Arrows are coloured based on the colors from the logo.
 